### PR TITLE
base: Install seccomp filter even if selinux is permissive

### DIFF
--- a/core/jni/com_android_internal_os_Zygote.cpp
+++ b/core/jni/com_android_internal_os_Zygote.cpp
@@ -126,8 +126,6 @@ static constexpr const char* kZygoteInitClassName = "com/android/internal/os/Zyg
 static jclass gZygoteInitClass;
 static jmethodID gGetOrCreateSystemServerClassLoader;
 
-static bool gIsSecurityEnforced = true;
-
 /**
  * True if the app process is running in its mount namespace.
  */
@@ -630,11 +628,6 @@ static void PreApplicationInit() {
 }
 
 static void SetUpSeccompFilter(uid_t uid, bool is_child_zygote) {
-  if (!gIsSecurityEnforced) {
-    ALOGI("seccomp disabled by setenforce 0");
-    return;
-  }
-
   // Apply system or app filter based on uid.
   if (uid >= AID_APP_START) {
     if (is_child_zygote) {
@@ -2325,11 +2318,6 @@ static void com_android_internal_os_Zygote_nativeAllowFileAcrossFork(
 
 static void com_android_internal_os_Zygote_nativeInstallSeccompUidGidFilter(
         JNIEnv* env, jclass, jint uidGidMin, jint uidGidMax) {
-  if (!gIsSecurityEnforced) {
-    ALOGI("seccomp disabled by setenforce 0");
-    return;
-  }
-
   bool installed = install_setuidgid_seccomp_filter(uidGidMin, uidGidMax);
   if (!installed) {
       RuntimeAbort(env, __LINE__, "Could not install setuid/setgid seccomp filter.");
@@ -2405,10 +2393,6 @@ static void com_android_internal_os_Zygote_nativeInitNativeState(JNIEnv* env, jc
   /*
    * Security Initialization
    */
-
-  // security_getenforce is not allowed on app process. Initialize and cache
-  // the value before zygote forks.
-  gIsSecurityEnforced = security_getenforce();
 
   selinux_android_seapp_context_init();
 


### PR DESCRIPTION
 * If selinux is permissive, Google decide to disable seccomp
   filter because debug tools like strace needs both them to be
   disabled to work.

 * This is fine for developers, but if one runs selinux permissive
   in production, it will be super easy for a macilious app to gain
   root access on Q+, with newly interoduced ZygotePreload API.

 * Technical details:
   https://github.com/dantmnf/BrokenSandbox
   https://github.com/vvb2060/Magica

Change-Id: I1a1208a0a82d36aeb49820972429d106919d6bce