### PR TITLE
base: Fix for issue causing keyboard to display over input text in certain conditions.

### DIFF
--- a/services/core/java/com/android/server/inputmethod/InputMethodManagerService.java
+++ b/services/core/java/com/android/server/inputmethod/InputMethodManagerService.java
@@ -2837,7 +2837,7 @@ public class InputMethodManagerService extends IInputMethodManager.Stub
                 return;
             }
             final IBinder targetWindow = mImeTargetWindowMap.get(startInputToken);
-            if (targetWindow != null && mLastImeTargetWindow != targetWindow) {
+            if (targetWindow != null) {
                 mWindowManagerInternal.updateInputMethodTargetWindow(token, targetWindow);
             }
             mLastImeTargetWindow = targetWindow;

--- a/services/core/java/com/android/server/wm/ActivityRecord.java
+++ b/services/core/java/com/android/server/wm/ActivityRecord.java
@@ -1037,6 +1037,8 @@ final class ActivityRecord extends WindowToken implements WindowManagerService.A
                 pw.print(" forceNewConfig="); pw.println(forceNewConfig);
         pw.print(prefix); pw.print("mActivityType=");
                 pw.println(activityTypeToString(getActivityType()));
+        pw.print(prefix); pw.print("mImeInsetsFrozenUntilStartInput=");
+                pw.println(mImeInsetsFrozenUntilStartInput);
         if (requestedVrComponent != null) {
             pw.print(prefix);
             pw.print("requestedVrComponent=");

--- a/services/core/java/com/android/server/wm/DisplayContent.java
+++ b/services/core/java/com/android/server/wm/DisplayContent.java
@@ -246,6 +246,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import com.android.internal.protolog.ProtoLogImpl;
 
 /**
  * Utility class for keeping track of the WindowStates and other pertinent contents of a
@@ -3969,11 +3970,18 @@ class DisplayContent extends RootDisplayArea implements WindowManagerPolicy.Disp
      * which controls the visibility and animation of the input method window.
      */
     void updateImeInputAndControlTarget(WindowState target) {
+        if(!(target == null || target.mActivityRecord == null)){
+            target.mActivityRecord.mImeInsetsFrozenUntilStartInput = false;
+        }
         if (mImeInputTarget != target) {
-            ProtoLog.i(WM_DEBUG_IME, "setInputMethodInputTarget %s", target);
-            if (target != null && target.mActivityRecord != null) {
-                target.mActivityRecord.mImeInsetsFrozenUntilStartInput = false;
+            if(ProtoLogCache.WM_DEBUG_IME_enabled){
+                String mTarget = String.valueOf(target);
+                ProtoLogImpl.i(WM_DEBUG_IME, -322743468, 0, (String) null, new Object[]{mTarget});
             }
+            //ProtoLog.i(WM_DEBUG_IME, "setInputMethodInputTarget %s", target);
+            //if (target != null && target.mActivityRecord != null) {
+            //    target.mActivityRecord.mImeInsetsFrozenUntilStartInput = false;
+            //}
             setImeInputTarget(target);
             updateImeControlTarget();
         }


### PR DESCRIPTION


Source comes from the reverse engineering of the February security update (sq1d.220205.003)of pixel6 model and had tested.
Fixed: Wechat keyboard cover chat viewGroup.
Signed-off-by: loserq <2650009628@qq.com>